### PR TITLE
Fix issue causing make dependencies to degenerate on successive builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,10 +50,10 @@ $(OBJ_OUT_DIR)%.o: $(OBJ_DIR)%.c | $(DIRECTORIES)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
 $(TEST_OUT_DIR)%: $(TEST_DIR)%.c | $(DIRECTORIES)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(filter %.c %.o,$^) $(LDFLAGS)
 
 $(CMD_OUT_DIR)%: $(CMD_DIR)%.c | $(DIRECTORIES)
-	$(CC) $(CFLAGS) -o $@ $^ $(LDFLAGS)
+	$(CC) $(CFLAGS) -o $@ $(filter %.c %.o,$^) $(LDFLAGS)
 
 
 # Delete the output logs from tests


### PR DESCRIPTION
Because all make dependencies (including headers) are globbed into the gcc invocation, the dependencies of targets (-MMD output) will be reduced on each invocation. Because the headers were specified on the compiler invocation, they are no longer added with an #include directive, and then gcc stops reporting them as dependencies.